### PR TITLE
Pi deployment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,7 @@ dependencies {
 
 bootRun {
     jvmArgs('-Dspring.output.ansi.enabled=always')
+    systemProperties = System.properties
 }
 
 

--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -86,7 +86,7 @@ auth2:
     clientId: "460384913941-o01p3pu021rrnq6ibbanenfrmg6r87at.apps.googleusercontent.com"
     clientSecret: "OZDv_3wkMh-83vLuBRdtrpXW"
     scope: "https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email"
-    serverUrl: "http://localhost:8080"
+    serverUrl: "http://localhost:${server.port}"
 
 ---
 hibernate:
@@ -96,42 +96,46 @@ hibernate:
         use_query_cache: false
         region.factory_class: org.hibernate.cache.ehcache.SingletonEhCacheRegionFactory
 
-#dataSource:
-#    pooled: true
-#    jmxExport: true
-#    driverClassName: com.mysql.jdbc.Driver
-#    username: clickerdbman
-#    password: password
-#
-#environments:
-#    development:
-#        dataSource:
-#            dbCreate: create-drop
-#            url: jdbc:mysql://localhost:3306/openclicker
-##            jdbc:h2:mem:devDb;MVCC=TRUE;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE
-#    test:
-#        dataSource:
-#            dbCreate: update
-#            url: jdbc:h2:mem:testDb;MVCC=TRUE;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE
-#    production:
-#        dataSource:
-#            dbCreate: none
+dataSource:
+    pooled: true
+    jmxExport: true
+    driverClassName: com.mysql.jdbc.Driver
+    username: lpuser
+    password: csc480
+
+environments:
+    development:
+        dataSource:
+            dbCreate: create-drop
+            url: jdbc:mysql://pi.cs.oswego.edu:3306/laker_polling
+#            jdbc:h2:mem:devDb;MVCC=TRUE;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE
+    test:
+        dataSource:
+            dbCreate: update
+            url: jdbc:h2:mem:testDb;MVCC=TRUE;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE
+    production:
+        dataSource:
+            dbCreate: none
+            url: jdbc:mysql://pi.cs.oswego.edu:3306/laker_polling
 #            url: jdbc:h2:./prodDb;MVCC=TRUE;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE
-#            properties:
-#                jmxEnabled: true
-#                initialSize: 5
-#                maxActive: 50
-#                minIdle: 5
-#                maxIdle: 25
-#                maxWait: 10000
-#                maxAge: 600000
-#                timeBetweenEvictionRunsMillis: 5000
-#                minEvictableIdleTimeMillis: 60000
-#                validationQuery: SELECT 1
-#                validationQueryTimeout: 3
-#                validationInterval: 15000
-#                testOnBorrow: true
-#                testWhileIdle: true
-#                testOnReturn: false
-#                jdbcInterceptors: ConnectionState
-#                defaultTransactionIsolation: 2 # TRANSACTION_READ_COMMITTED
+            properties:
+                jmxEnabled: true
+                initialSize: 5
+                maxActive: 50
+                minIdle: 5
+                maxIdle: 25
+                maxWait: 10000
+                maxAge: 600000
+                timeBetweenEvictionRunsMillis: 5000
+                minEvictableIdleTimeMillis: 60000
+                validationQuery: SELECT 1
+                validationQueryTimeout: 3
+                validationInterval: 15000
+                testOnBorrow: true
+                testWhileIdle: true
+                testOnReturn: false
+                jdbcInterceptors: ConnectionState
+                defaultTransactionIsolation: 2 # TRANSACTION_READ_COMMITTED
+
+server:
+    port: 50678

--- a/grails-app/init/edu/oswego/edu/cs/lakerpolling/Application.groovy
+++ b/grails-app/init/edu/oswego/edu/cs/lakerpolling/Application.groovy
@@ -1,0 +1,10 @@
+package edu.oswego.edu.cs.lakerpolling
+
+import grails.boot.GrailsApp
+import grails.boot.config.GrailsAutoConfiguration
+
+class Application extends GrailsAutoConfiguration {
+    static void main(String[] args) {
+        GrailsApp.run(Application, args)
+    }
+}


### PR DESCRIPTION
Made all changes necessary to allow us to deploy the grails app on Pi. I chose a random port number to host it at, but also added the functionality to change the port via a command line argument for more flexibility. The grails app can be started on Pi by simply running the command "gradle bootrun". This pull request is only applicable if we are going to host the server on Pi and not Heroku.